### PR TITLE
FEAT/STORE: 홈, 가게 등록 api 추가

### DIFF
--- a/thirtyone/store/admin.py
+++ b/thirtyone/store/admin.py
@@ -1,10 +1,10 @@
 from django.contrib import admin
-from .models import Store, Order, StoreType
+from .models import Store, Order
 
 # Register your models here.
 
 
-admin.site.register(StoreType)
+#admin.site.register(StoreType)
 
 # 어드민에서 주문서에서 세부 내역 더 보고싶어서 추가함
 class OrderAdmin(admin.ModelAdmin):

--- a/thirtyone/store/models.py
+++ b/thirtyone/store/models.py
@@ -84,28 +84,37 @@ class Store(models.Model):
 
 
 #상품 카테고리 모델 ProductType
-class ProductType(models.Model):
-    class ProductCategory(models.TextChoices):
-        BAKERY = 'BAK', '빵 & 간식류'
-        BUTCHER_SHOP = 'BUT', '정육 제품'
-        FRUITS = 'FRU', '과일류'
-        VEGETABLES = 'VEG', '채소류'
-        SIDE_DISH_STORE = 'SID', '반찬 가게'
-        SNACKS = 'ETC', '기타'
+# class ProductType(models.Model):
+#     class ProductCategory(models.TextChoices):
+#         BAKERY = 'BAK', '빵 & 간식류'
+#         BUTCHER_SHOP = 'BUT', '정육 제품'
+#         FRUITS = 'FRU', '과일류'
+#         VEGETABLES = 'VEG', '채소류'
+#         SIDE_DISH_STORE = 'SID', '반찬 가게'
+#         SNACKS = 'ETC', '기타'
 
-    part = models.CharField(
-        max_length=3,  # 최대 3자까지 허용(BAK이런거)
-        choices=ProductCategory.choices, # 선택지를 ProductCategory 클래스에서 가져옴
-        default=ProductCategory.BAKERY, # 기본값을 '빵 & 간식류'로 설정
-    )
+#     part = models.CharField(
+#         max_length=3,  # 최대 3자까지 허용(BAK이런거)
+#         choices=ProductCategory.choices, # 선택지를 ProductCategory 클래스에서 가져옴
+#         default=ProductCategory.BAKERY, # 기본값을 '빵 & 간식류'로 설정
+#     )
 
 
-    def __str__(self):
-        return self.name
+#     def __str__(self):
+#         return self.name
 
 
 #떨이상품 모델 SaleProduct 
 class SaleProduct(models.Model):
+    TYPE_CHOICES = [
+        ('BAK', '빵 & 간식류'),
+        ('BUT', '정육 제품'),
+        ('FRU', '과일류'),
+        ('VEG', '채소류'),
+        ('SID', '반찬 가게'),
+        ('BUT', '정육점'),
+        ('ETC', '기타'),
+    ]
     name = models.CharField(max_length=255) # 떨이 상품명
     amount = models.IntegerField() # 떨이 수량
     photo = models.ImageField(upload_to='SaleProduct_phothos') # 떨이 상품 사진
@@ -116,7 +125,7 @@ class SaleProduct(models.Model):
     # 판매자(Store) : 떨이상품(SaleProduct) = 1 : N
     store = models.ForeignKey(Store, on_delete=models.CASCADE)
     #상품 카테고리(ProductType) : 떨이 상품(SaleProduct)   = 1 : N
-    product_type = models.ForeignKey(ProductType,on_delete=models.CASCADE)
+    product_type = models.CharField(max_length=3, choices=TYPE_CHOICES)
 
     def __str__(self):
         return self.get_part_display()  # 선택된 값의 레이블 반환

--- a/thirtyone/store/models.py
+++ b/thirtyone/store/models.py
@@ -15,35 +15,49 @@ def generate_code():
 
 # 기본 StoreType 생성 함수
 #밑에 Store에서 StoreType 외래키로 받을 때 default 값을 1로 했을 떄 StoreType에 객체가 먼저 생성이 안되어서 오류가 생겨서 일케함
-def get_default_store_type_id():
-    store_type, created = StoreType.objects.get_or_create(part=StoreType.StoreCategory.FRUITS_VEGETABLES)
-    return store_type.id
+# def get_default_store_type_id():
+#     store_type, created = StoreType.objects.get_or_create(part=StoreType.StoreCategory.FRUITS_VEGETABLES)
+#     return store_type.id
 
 
 #가게 업종 모델 StoreType
-class StoreType(models.Model):
-    class StoreCategory(models.TextChoices):
-        FRUITS_VEGETABLES = 'FRV', '과일 및 야채'
-        BUTCHER_SHOP = 'BUT', '정육점'
-        BAKERY = 'BAK', '베이커리'
-        SIDE_DISH_STORE = 'SID', '반찬 가게'
-        SEAFOOD_STORE = 'SEA', '수산물 가게'
-        RICE_CAKE_SHOP = 'RIC', '떡 가게'
-        PREPARED_FOOD = 'PRE', '조리 식품'
-        SNACKS = 'SNA', '간식류'
+# class StoreType(models.Model):
+#     class StoreCategory(models.TextChoices):
+#         FRUITS_VEGETABLES = 'FRV', '과일 및 야채'
+#         BUTCHER_SHOP = 'BUT', '정육점'
+#         BAKERY = 'BAK', '베이커리'
+#         SIDE_DISH_STORE = 'SID', '반찬 가게'
+#         SEAFOOD_STORE = 'SEA', '수산물 가게'
+#         RICE_CAKE_SHOP = 'RIC', '떡 가게'
+#         PREPARED_FOOD = 'PRE', '조리 식품'
+#         SNACKS = 'SNA', '간식류'
 
-    part = models.CharField(
-        max_length=3,  # 최대 3자까지 허용(FRV이런거)
-        choices=StoreCategory.choices, # 선택지를 StoreCategory 클래스에서 가져옴
-        default=StoreCategory.FRUITS_VEGETABLES, # 기본값을 '과일 및 야채'로 설정
-    )
+#     part = models.CharField(
+#         max_length=3,  # 최대 3자까지 허용(FRV이런거)
+#         choices=StoreCategory.choices, # 선택지를 StoreCategory 클래스에서 가져옴
+#         default=StoreCategory.FRUITS_VEGETABLES, # 기본값을 '과일 및 야채'로 설정
+#     )
 
-    def __str__(self):
-        return self.get_part_display()  # 선택된 값의 레이블 반환
+#     def __str__(self):
+#         return self.get_part_display()  # 선택된 값의 레이블 반환
 
 
 # 판매자 모델 정의
 class Store(models.Model): 
+    # 가게업종은 생각해보니까 store에서만 쓰고 한가게에 하나의 업종만 선택 가능해서 이렇게 해줌
+    # 약간 회원에서 성별 선택 같은 느낌(..?)
+    # 원래 방법대로 하니까 admin에서 가게등록 오류가 뜸..
+    # 혹시 몰라서 원래 모델은 주석처리 해둠
+    TYPE_CHOICES = [
+        ('FRV', '과일 및 야채'),
+        ('BUT', '정육점'),
+        ('BAK', '베이커리'),
+        ('SID', '반찬 가게'),
+        ('SEA', '수산물 가게'),
+        ('BUT', '정육점'),
+        ('RIC', '떡 가게'),
+        ('SNA', '간식류'),
+    ]
     name = models.CharField(max_length=50) # 가게 이름
     photo = models.ImageField(upload_to='store_phothos/') # 가게 사진
     address = models.CharField(max_length=255) #가게 주소
@@ -55,7 +69,7 @@ class Store(models.Model):
     code = models.CharField(max_length=1, unique=True, editable=False)  # 가게 고유 알파벳 코드
 
     # 판매자(Store) : 가게업종(StoreType) = N : 1
-    type = models.ForeignKey(StoreType, on_delete=models.CASCADE, default=get_default_store_type_id)
+    type = models.CharField(max_length=3, choices=TYPE_CHOICES)
 
 
     #새로운 Store객체를 저장 할 때, store_code가 없으면, 다시 호출해서 설정함

--- a/thirtyone/store/serializers.py
+++ b/thirtyone/store/serializers.py
@@ -10,3 +10,8 @@ class StoreSerializer(serializers.ModelSerializer):
     class Meta:
         model = Store
         fields = '__all__'
+
+class CreateSaleProductSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SaleProduct
+        fields = ['photo']

--- a/thirtyone/store/serializers.py
+++ b/thirtyone/store/serializers.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+from .models import *
+
+class CreateStoreSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Store
+        fields = ['name', 'photo', 'address', 'open_time', 'close_time', 'tel', 'latitude', 'longitude', 'type']
+
+class StoreSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Store
+        fields = '__all__'

--- a/thirtyone/store/urls.py
+++ b/thirtyone/store/urls.py
@@ -1,0 +1,9 @@
+from django.contrib import admin
+from django.urls import path, include
+from . import views
+
+urlpatterns = [
+    path('create/', views.create_store, name='create_store'), # store 앱 url 연결
+    path('home/', views.view_store, name='home'),
+    # 우리가 파리바게트 판매자를 기준으로 홈화면 띄우기로 했어서 이렇게 함
+]

--- a/thirtyone/store/views.py
+++ b/thirtyone/store/views.py
@@ -1,3 +1,21 @@
 from django.shortcuts import render
+from django.shortcuts import get_object_or_404
+from .serializers import *
+from .models import *
+from rest_framework.response import Response
+from rest_framework.decorators import api_view
 
-# Create your views here.
+@api_view(['POST'])
+def create_store(request):
+    serializer = CreateStoreSerializer(data=request.data)
+    if serializer.is_valid():
+        store = serializer.save()
+        return Response({"message": "create store successful"}, status=201)
+    return Response(serializer.errors, status=400)
+
+@api_view(['GET'])
+def view_store(request): 
+    store = get_object_or_404(Store, id=1)
+    # store id 값 1로 고정해줌(파리바게트 인하대점)
+    serializer = StoreSerializer(store)
+    return Response(serializer.data, status=200)

--- a/thirtyone/thirtyone/urls.py
+++ b/thirtyone/thirtyone/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('store/', include('store.urls')), # store 앱 url 연결
 ]


### PR DESCRIPTION
### 작업
1. "store/home/", "store/create" api 추가
***
### 참고사항
1. store/models.py 에서 StoreType, ProductType 클래스 주석처리 하고, 각자 Store, SaleProduct 모델안에 choice로 넣어줌