### PR TITLE
FEAT/STORE: 떨이상품 등록 및 떨이기록 생성 api 추가

### DIFF
--- a/thirtyone/store/admin.py
+++ b/thirtyone/store/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Store, Order, SaleProduct, SaleRecord
+from .models import *
 
 # Register your models here.
 

--- a/thirtyone/store/admin.py
+++ b/thirtyone/store/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Store, Order
+from .models import Store, Order, SaleProduct, SaleRecord
 
 # Register your models here.
 
@@ -17,3 +17,14 @@ class StoreAdmin(admin.ModelAdmin):
     list_display = ('name', 'code', 'address', 'open_time', 'close_time', 'tel')
 
 admin.site.register(Store, StoreAdmin)
+
+class SaleProductAdmin(admin.ModelAdmin):
+    list_display = ('store', 'name', 'amount', 'price', 'sale_price', 'content', 'product_type')
+
+admin.site.register(SaleProduct, SaleProductAdmin)
+
+
+class SaleRecordAdmin(admin.ModelAdmin):
+    list_display = ('sale_product', 'date', 'amount')
+
+admin.site.register(SaleRecord, SaleRecordAdmin)

--- a/thirtyone/store/models.py
+++ b/thirtyone/store/models.py
@@ -116,10 +116,10 @@ class SaleProduct(models.Model):
         ('ETC', '기타'),
     ]
     name = models.CharField(max_length=255) # 떨이 상품명
-    amount = models.IntegerField() # 떨이 수량
-    photo = models.ImageField(upload_to='SaleProduct_phothos') # 떨이 상품 사진
-    price = models.IntegerField() # 상품 정가
-    sale_price = models.IntegerField() # 상품 할인가
+    amount = models.IntegerField(default=0) # 떨이 수량
+    photo = models.ImageField(upload_to='SaleProduct_phothos', null=True) # 떨이 상품 사진
+    price = models.IntegerField(default=0) # 상품 정가
+    sale_price = models.IntegerField(default=0) # 상품 할인가
     content = models.TextField() # 상품 설명
 
     # 판매자(Store) : 떨이상품(SaleProduct) = 1 : N
@@ -135,13 +135,13 @@ class SaleProduct(models.Model):
 #상품 실적 모델 SaleRecord
 class SaleRecord(models.Model):
     date = models.DateField() #날짜 저장 (시간 저장 안되도 ㄱㅊ으려나??)
-    amount = models.IntegerField() # 상품별 당일 수량 저장
+    amount = models.IntegerField(default=0) # 상품별 당일 수량 저장
 
     #떨이 상품(SaleProduct) : 상품 실적(SaleRecord) = 1 : N
     sale_product = models.ForeignKey(SaleProduct, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.amount    
+        return f'{self.sale_product.name} - {self.date}'    
 
 
 #주문 모델 Order

--- a/thirtyone/store/models.py
+++ b/thirtyone/store/models.py
@@ -128,7 +128,7 @@ class SaleProduct(models.Model):
     product_type = models.CharField(max_length=3, choices=TYPE_CHOICES)
 
     def __str__(self):
-        return self.get_part_display()  # 선택된 값의 레이블 반환
+        return self.name  # 선택된 값의 레이블 반환
 
 
 
@@ -141,7 +141,7 @@ class SaleRecord(models.Model):
     sale_product = models.ForeignKey(SaleProduct, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.content    
+        return self.amount    
 
 
 #주문 모델 Order

--- a/thirtyone/store/serializers.py
+++ b/thirtyone/store/serializers.py
@@ -17,22 +17,21 @@ class CreateSaleProductSerializer(serializers.ModelSerializer):
         model = SaleProduct
         fields = ['photo', 'name', 'product_type', 'price', 'sale_price', 'amount', 'content']
 
-    # update랑 create는 instance(떨이상품)을 가지고 update_sale_record에 사용하기 위해서 있는 함수 느낌..?
-    def update(self, instance, validated_data):
-        # 떨이 상품이 새로 업데이트 될때 수행됨
-        instance = super().update(instance, validated_data)
-        self.update_sale_record(instance)
-        return instance
+    
 
-    def create(self, validated_data):
-        instance = super().create(validated_data)
-        self.update_sale_record(instance)
-        return instance
+    def save(self, **kwargs):
+        # 새 인스턴스가 생성되거나 기존 인스턴스가 업데이트될 때 호출됨
+        sale_product = super().save(**kwargs)
+        # **kwargs : keyword arguments 예상하지 못한 키워드 인수도 받을 수 있음
+    
+        # SaleRecord 업데이트
+        self.update_sale_record(sale_product)
+
+        return sale_product
 
     def update_sale_record(self, sale_product):
         today = datetime.date.today()
         sale_record, created = SaleRecord.objects.get_or_create(date=today, sale_product=sale_product)
-            
         if created:
             sale_record.amount = sale_product.amount
         else:

--- a/thirtyone/store/serializers.py
+++ b/thirtyone/store/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from .models import *
+import datetime
 
 class CreateStoreSerializer(serializers.ModelSerializer):
     class Meta:
@@ -14,4 +15,26 @@ class StoreSerializer(serializers.ModelSerializer):
 class CreateSaleProductSerializer(serializers.ModelSerializer):
     class Meta:
         model = SaleProduct
-        fields = ['photo']
+        fields = ['photo', 'name', 'product_type', 'price', 'sale_price', 'amount', 'content']
+
+    # update랑 create는 instance(떨이상품)을 가지고 update_sale_record에 사용하기 위해서 있는 함수 느낌..?
+    def update(self, instance, validated_data):
+        # 떨이 상품이 새로 업데이트 될때 수행됨
+        instance = super().update(instance, validated_data)
+        self.update_sale_record(instance)
+        return instance
+
+    def create(self, validated_data):
+        instance = super().create(validated_data)
+        self.update_sale_record(instance)
+        return instance
+
+    def update_sale_record(self, sale_product):
+        today = datetime.date.today()
+        sale_record, created = SaleRecord.objects.get_or_create(date=today, sale_product=sale_product)
+            
+        if created:
+            sale_record.amount = sale_product.amount
+        else:
+            sale_record.amount += sale_product.amount
+        sale_record.save()

--- a/thirtyone/store/serializers.py
+++ b/thirtyone/store/serializers.py
@@ -19,7 +19,7 @@ class CreateSaleProductSerializer(serializers.ModelSerializer):
 
     
 
-    def save(self, **kwargs):
+    def save(self, **kwargs): # save 함수 오버라이딩
         # 새 인스턴스가 생성되거나 기존 인스턴스가 업데이트될 때 호출됨
         sale_product = super().save(**kwargs)
         # **kwargs : keyword arguments 예상하지 못한 키워드 인수도 받을 수 있음
@@ -32,8 +32,8 @@ class CreateSaleProductSerializer(serializers.ModelSerializer):
     def update_sale_record(self, sale_product):
         today = datetime.date.today()
         sale_record, created = SaleRecord.objects.get_or_create(date=today, sale_product=sale_product)
-        if created:
+        if created: # 해당 상품에 대해 처음 떨이 기록 생성됐을 경우
             sale_record.amount = sale_product.amount
-        else:
+        else: # 원래 있던 경우는 누적합으로
             sale_record.amount += sale_product.amount
         sale_record.save()

--- a/thirtyone/store/urls.py
+++ b/thirtyone/store/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path('home/', views.view_store, name='home'),
     # 우리가 파리바게트 판매자를 기준으로 홈화면 띄우기로 했어서 이렇게 함
     path('create/<int:pk>/product', views.create_product, name="create_product"),
+    path('<int:pk>/product/list', views.list_product, name="list_product"),
 ]

--- a/thirtyone/store/urls.py
+++ b/thirtyone/store/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path('create/', views.create_store, name='create_store'), # store 앱 url 연결
     path('home/', views.view_store, name='home'),
     # 우리가 파리바게트 판매자를 기준으로 홈화면 띄우기로 했어서 이렇게 함
+    path('create/<int:pk>/product', views.create_product, name="create_product"),
 ]

--- a/thirtyone/store/views.py
+++ b/thirtyone/store/views.py
@@ -23,7 +23,7 @@ def view_store(request):
 @api_view(['POST'])
 def create_product(request, pk):
     store = get_object_or_404(Store, pk=pk)
-    name = request.data.get(name=name)
+    name = request.data.get('name')
     sale_product, created  = SaleProduct.objects.get_or_create(store=store, name=name)
     
     if created:

--- a/thirtyone/store/views.py
+++ b/thirtyone/store/views.py
@@ -19,3 +19,24 @@ def view_store(request):
     # store id 값 1로 고정해줌(파리바게트 인하대점)
     serializer = StoreSerializer(store)
     return Response(serializer.data, status=200)
+
+@api_view(['POST'])
+def create_product(request, pk):
+    store = get_object_or_404(Store, pk=pk)
+    name = request.data.get(name=name)
+    sale_product, created  = SaleProduct.objects.get_or_create(store=store, name=name)
+    
+    if created:
+        serializer = CreateSaleProductSerializer(sale_product, data=request.data)
+    else :
+        serializer = CreateSaleProductSerializer(sale_product, data=request.data, partial=True)
+
+    if serializer.is_valid():
+        serializer.save()
+        if created:
+            return Response({'message': 'Sale product created successfully.', 'data': serializer.data}, status=201)
+        else:
+            return Response({'message': 'Sale product updated successfully.', 'data': serializer.data}, status=200)
+        
+    return Response(serializer.errors, status=400)
+

--- a/thirtyone/store/views.py
+++ b/thirtyone/store/views.py
@@ -40,3 +40,8 @@ def create_product(request, pk):
         
     return Response(serializer.errors, status=400)
 
+@api_view(['GET'])
+def list_product(request, pk):
+    store = get_object_or_404(Store, pk=pk)
+    products = SaleProduct.objects.filter(store=store)
+    return Response({'products': list(products.values()), 'store_name':store.name}, status=200)


### PR DESCRIPTION
## 작업
1. models.py/SaleProduct랑 SaleRecord에서 Integer 필드 default=0 추가해줌
2. models.py/SaleProduct에서 photo에서 null=True로 바꿔줌(postman에서 사진 없이 등록하기 위해서)
3. serializers.py/CreateSaleProductSerializer 만들어서 떨이 상품 입력 받을 때 필요한 필드값 지정해주고, save( ) 함수 오버라이딩 해서 save( ) 할 때 마다 떨이 기록 객체 생성 되거나 수정되게 해줌
4. 그리고 views.py/create_product를 원래 있던 제품을 다시 떨이상품으로 등록하는 거여도 사용자 입장에선 다시 다 입력하는거니까 걍 다 POST로 받는게 더 나을거 같아서 PATCH 없이 POST로 해줌 
***
## 참고사항
떨이상품 등록을 admin 페이지에서 하면 sale_record 생성이 안됨
그래서 postman에서 사진을 제외하고 필드 입력해서 떨이상품 등록한 다음에 admin에서 사진만 추가하는 식으로 해야할 듯(아직 사진을 json으로 어케 줘야되는지를 모름..ㅋㅋ)
![image](https://github.com/user-attachments/assets/d272184d-0438-45ba-ad1b-6f8ed4d95aaf)
